### PR TITLE
Revert "fix(container): update spegel group ( v0.0.28 → v0.0.29 ) (patch)"

### DIFF
--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -61,7 +61,7 @@ releases:
   - name: spegel
     namespace: kube-system
     chart: oci://ghcr.io/spegel-org/helm-charts/spegel
-    version: v0.0.29
+    version: v0.0.28
     values:
       - ../apps/kube-system/spegel/app/helm-values.yaml
     needs:

--- a/kubernetes/flux/repositories/oci/spegel.yaml
+++ b/kubernetes/flux/repositories/oci/spegel.yaml
@@ -12,4 +12,4 @@ spec:
     operation: copy
   url: oci://ghcr.io/spegel-org/helm-charts/spegel
   ref:
-    tag: v0.0.29
+    tag: v0.0.28


### PR DESCRIPTION
Reverts jfroy/flatops#784

There may be a performance/timeout issue with 0.0.30 and Talos 1.9.1.