### PR TITLE
feat(openebs): deploy just localpv

### DIFF
--- a/kubernetes/apps/openebs-system/openebs-localpv/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs-localpv/app/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openebs-localpv
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/openebs/charts/localpv-provisioner
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openebs-localpv
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: openebs-localpv
+  driftDetection:
+    mode: enabled
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    global:
+      imageRegistry: quay.io/
+    localpv:
+      basePath: /var/openebs/local
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+    hostpathClass:
+      name: openebs-hostpath
+    analytics:
+      enabled: false

--- a/kubernetes/apps/openebs-system/openebs-localpv/app/kustomization.yaml
+++ b/kubernetes/apps/openebs-system/openebs-localpv/app/kustomization.yaml
@@ -3,10 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./openebs/ks.yaml
-  - ./openebs-localpv/ks.yaml
-components:
-  - ../../components/common
-transformers:
-  - ./transformers
+  - ./helmrelease.yaml

--- a/kubernetes/apps/openebs-system/openebs-localpv/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs-localpv/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openebs-localpv
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: openebs-system
+  path: ./kubernetes/apps/openebs-system/openebs-localpv/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenEBS LocalPV storage provisioner configuration to enable persistent local volume support in the cluster.
  * Configured automated reconciliation with drift detection and remediation policies for storage deployment.
  * Integrated node scheduling tolerations for control-plane nodes and configured hostpath storage base paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->