### PR TITLE
chore(flux): clean up ks common metadata

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app cert-manager
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: envoy-gateway
       namespace: network
@@ -30,7 +27,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cert-manager-issuers
+  name: cert-manager-issuers
 spec:
   dependsOn:
     - name: cert-manager

--- a/kubernetes/apps/cert-manager/trust-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/trust-manager/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app trust-manager
+  name: trust-manager
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager
   path: ./kubernetes/apps/cert-manager/trust-manager/app
@@ -24,11 +21,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cluster-ca-bundle
+  name: cluster-ca-bundle
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: trust-manager
   path: ./kubernetes/apps/cert-manager/trust-manager/cluster-ca-bundle

--- a/kubernetes/apps/cnpg-system/barman-cloud/ks.yaml
+++ b/kubernetes/apps/cnpg-system/barman-cloud/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cnpg-barman-cloud
+  name: cnpg-barman-cloud
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/cnpg-system/barman-cloud/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/cnpg-system/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/cnpg-system/cloudnative-pg/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cloudnative-pg
+  name: cloudnative-pg
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/cnpg-system/cloudnative-pg/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/database/influxdb/ks.yaml
+++ b/kubernetes/apps/database/influxdb/ks.yaml
@@ -7,8 +7,6 @@ metadata:
 spec:
   commonMetadata:
     labels:
-      app.kubernetes.io/instance: *app
-      app.kubernetes.io/name: *app
       app.kubernetes.io/part-of: powerwall-dashboard
   components:
     - ../../../../components/volsync

--- a/kubernetes/apps/default/autobrr/ks.yaml
+++ b/kubernetes/apps/default/autobrr/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app autobrr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/autobrr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/buildkit/ks.yaml
+++ b/kubernetes/apps/default/buildkit/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app buildkit
+  name: buildkit
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/buildkit/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/changedetection/ks.yaml
+++ b/kubernetes/apps/default/changedetection/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app changedetection
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/changedetection/app

--- a/kubernetes/apps/default/crd-schema-publisher/ks.yaml
+++ b/kubernetes/apps/default/crd-schema-publisher/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app crd-schema-publisher
+  name: crd-schema-publisher
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/crd-schema-publisher/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/dawarich/ks.yaml
+++ b/kubernetes/apps/default/dawarich/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app dawarich
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/dawarich/app

--- a/kubernetes/apps/default/docker-registry-ui/ks.yaml
+++ b/kubernetes/apps/default/docker-registry-ui/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app docker-registry-ui
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/docker-registry-ui/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/docling/ks.yaml
+++ b/kubernetes/apps/default/docling/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app docling
+  name: docling
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/docling/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/esphome-device-builder/ks.yaml
+++ b/kubernetes/apps/default/esphome-device-builder/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app esphome-device-builder
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/esphome-device-builder/app

--- a/kubernetes/apps/default/glance/ks.yaml
+++ b/kubernetes/apps/default/glance/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app glance
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/glance/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/gluetun/ks.yaml
+++ b/kubernetes/apps/default/gluetun/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app gluetun-update
+  name: gluetun-update
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/gluetun/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app homebox
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/homebox/app

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app homepage
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/envoy-gateway-oidc
   path: ./kubernetes/apps/default/homepage/app

--- a/kubernetes/apps/default/hypermind/ks.yaml
+++ b/kubernetes/apps/default/hypermind/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app hypermind
+  name: hypermind
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/hypermind/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app immich
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/immich/app
   prune: true
   sourceRef:
@@ -28,9 +25,6 @@ kind: Kustomization
 metadata:
   name: &app immichframe
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/immich/frame
@@ -55,8 +49,6 @@ metadata:
 spec:
   commonMetadata:
     labels:
-      app.kubernetes.io/instance: immich
-      app.kubernetes.io/name: valkey
       app.kubernetes.io/part-of: immich
   path: ./kubernetes/apps/default/immich/valkey
   prune: true

--- a/kubernetes/apps/default/jellyfin/ks.yaml
+++ b/kubernetes/apps/default/jellyfin/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app jellyfin
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/jellyfin/app

--- a/kubernetes/apps/default/karakeep/ks.yaml
+++ b/kubernetes/apps/default/karakeep/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app karakeep
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/karakeep/app

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app mealie
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/mealie/app

--- a/kubernetes/apps/default/mediamanager/ks.yaml
+++ b/kubernetes/apps/default/mediamanager/ks.yaml
@@ -3,12 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app mediamanager
+  name: mediamanager
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-      app.kubernetes.io/part-of: mediamanager
   path: ./kubernetes/apps/default/mediamanager/app
   prune: true
   sourceRef:
@@ -23,12 +19,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app mediamanager-metadata-relay
+  name: mediamanager-metadata-relay
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-      app.kubernetes.io/part-of: mediamanager
   path: ./kubernetes/apps/default/mediamanager/metadata-relay
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/memos/ks.yaml
+++ b/kubernetes/apps/default/memos/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app memos
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/memos/app

--- a/kubernetes/apps/default/miniflux/ks.yaml
+++ b/kubernetes/apps/default/miniflux/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app miniflux
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/miniflux/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/netbox/ks.yaml
+++ b/kubernetes/apps/default/netbox/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app netbox
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/netbox/app

--- a/kubernetes/apps/default/nextflux/ks.yaml
+++ b/kubernetes/apps/default/nextflux/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app nextflux
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/nextflux/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/octoeverywhere-bambu-connect/ks.yaml
+++ b/kubernetes/apps/default/octoeverywhere-bambu-connect/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app octoeverywhere-bambu-connect
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/octoeverywhere-bambu-connect/app

--- a/kubernetes/apps/default/ollama/ks.yaml
+++ b/kubernetes/apps/default/ollama/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app ollama
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/ollama/app

--- a/kubernetes/apps/default/open-webui/ks.yaml
+++ b/kubernetes/apps/default/open-webui/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app open-webui
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/open-webui/app

--- a/kubernetes/apps/default/openspoolman/ks.yaml
+++ b/kubernetes/apps/default/openspoolman/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app openspoolman
+  name: openspoolman
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/openspoolman/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/paperless/ks.yaml
+++ b/kubernetes/apps/default/paperless/ks.yaml
@@ -5,10 +5,6 @@ kind: Kustomization
 metadata:
   name: &app paperless
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-      app.kubernetes.io/part-of: paperless
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/paperless/app
@@ -31,10 +27,6 @@ spec:
 # metadata:
 #   name: &app paperless-ai
 # spec:
-#   commonMetadata:
-#     labels:
-#       app.kubernetes.io/name: *app
-#       app.kubernetes.io/part-of: paperless
 #   components:
 #     - ../../../../components/volsync
 #   path: ./kubernetes/apps/default/paperless/ai
@@ -57,10 +49,6 @@ spec:
 # metadata:
 #   name: &app paperless-gpt
 # spec:
-#   commonMetadata:
-#     labels:
-#       app.kubernetes.io/name: *app
-#       app.kubernetes.io/part-of: paperless
 #   components:
 #     - ../../../../components/volsync
 #   path: ./kubernetes/apps/default/paperless/gpt

--- a/kubernetes/apps/default/pgadmin/ks.yaml
+++ b/kubernetes/apps/default/pgadmin/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app pgadmin
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/pgadmin/app

--- a/kubernetes/apps/default/photon/ks.yaml
+++ b/kubernetes/apps/default/photon/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app photon
+  name: photon
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/photon/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app plex
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/plex/app

--- a/kubernetes/apps/default/pocket-id/ks.yaml
+++ b/kubernetes/apps/default/pocket-id/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app pocket-id
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/pocket-id/app

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app prowlarr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/envoy-gateway-oidc
   path: ./kubernetes/apps/default/prowlarr/app

--- a/kubernetes/apps/default/pvforecast/ks.yaml
+++ b/kubernetes/apps/default/pvforecast/ks.yaml
@@ -3,11 +3,10 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app pvforecast
+  name: pvforecast
 spec:
   commonMetadata:
     labels:
-      app.kubernetes.io/name: *app
       app.kubernetes.io/part-of: powerwall-dashboard
   path: ./kubernetes/apps/default/pvforecast/app
   prune: true

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app qbittorrent
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/qbittorrent/app

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app qui
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/qui/app

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app radarr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/envoy-gateway-oidc
     - ../../../../components/volsync

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app recyclarr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/recyclarr/app

--- a/kubernetes/apps/default/registry/ks.yaml
+++ b/kubernetes/apps/default/registry/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app registry
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/registry/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app sabnzbd
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/envoy-gateway-oidc
     - ../../../../components/volsync

--- a/kubernetes/apps/default/shelfmark/ks.yaml
+++ b/kubernetes/apps/default/shelfmark/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app shelfmark
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/shelfmark/app

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app sonarr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/envoy-gateway-oidc
     - ../../../../components/volsync

--- a/kubernetes/apps/default/spoolman/ks.yaml
+++ b/kubernetes/apps/default/spoolman/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app spoolman
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/spoolman/app

--- a/kubernetes/apps/default/stash/ks.yaml
+++ b/kubernetes/apps/default/stash/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app stash
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/default/stash/app

--- a/kubernetes/apps/default/tracearr/ks.yaml
+++ b/kubernetes/apps/default/tracearr/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app tracearr
+  name: tracearr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/default/tracearr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app external-secrets
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/kubernetes/apps/flux-system/instance/ks.yaml
+++ b/kubernetes/apps/flux-system/instance/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app flux-instance
+  name: flux-instance
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/flux-system/instance/ks
   prune: true
   sourceRef:

--- a/kubernetes/apps/flux-system/operator/ks.yaml
+++ b/kubernetes/apps/flux-system/operator/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app flux-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/gpu-operator/gpu-operator/ks.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app gpu-operator
+  name: gpu-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/gpu-operator/gpu-operator/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/ingress-certificates/ingress-certificates/ks.yaml
+++ b/kubernetes/apps/ingress-certificates/ingress-certificates/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app ingress-certificates
+  name: ingress-certificates
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/ingress-certificates/ingress-certificates/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cilium
+  name: cilium
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   # NOTE: Cannot depend on cilium-config to prevent helm stalls
   dependsOn:
     - name: cert-manager
@@ -28,11 +25,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cilium-config
+  name: cilium-config
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   # NOTE: Cannot depend on cilium to prevent helm stalls
   path: ./kubernetes/apps/kube-system/cilium/config
   prune: true

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app coredns
+  name: coredns
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/coredns/app
   prune: false  # don't GC coredns to avoid unwanted DR
   sourceRef:

--- a/kubernetes/apps/kube-system/cpufreq/ks.yaml
+++ b/kubernetes/apps/kube-system/cpufreq/ks.yaml
@@ -5,10 +5,6 @@ kind: Kustomization
 metadata:
   name: cpufreq-kantai1
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: cpufreq
-      app.kubernetes.io/instance: kantai1
   path: ./kubernetes/apps/kube-system/cpufreq/kantai1
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/csi-driver-smb/ks.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-smb/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app csi-driver-smb
+  name: csi-driver-smb
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/csi-driver-smb/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app descheduler
+  name: descheduler
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/descheduler/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/gateway-crd/ks.yaml
+++ b/kubernetes/apps/kube-system/gateway-crd/ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app gateway-crd
+  name: gateway-crd
 spec:
   path: ./kubernetes/apps/kube-system/gateway-crd/experimental
   prune: false  # don't GC CRDs

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app generic-device-plugin
+  name: generic-device-plugin
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/generic-device-plugin/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/k8s-digester/ks.yaml
+++ b/kubernetes/apps/kube-system/k8s-digester/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app k8s-digester
+  name: k8s-digester
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/k8s-digester/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/kubelet-csr-approver/ks.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app kubelet-csr-approver
+  name: kubelet-csr-approver
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/kubelet-csr-approver/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app metrics-server
+  name: metrics-server
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/metrics-server/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/multus/ks.yaml
+++ b/kubernetes/apps/kube-system/multus/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app multus
+  name: multus
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -30,11 +27,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app multus-networks
+  name: multus-networks
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: multus
   path: ./kubernetes/apps/kube-system/multus/networks

--- a/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app node-feature-discovery
+  name: node-feature-discovery
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/node-feature-discovery/app
   prune: true
   sourceRef:
@@ -22,11 +19,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app node-feature-discovery-custom
+  name: node-feature-discovery-custom
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: node-feature-discovery
   path: ./kubernetes/apps/kube-system/node-feature-discovery/custom

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app reloader
+  name: reloader
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/reloader/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app snapshot-controller
+  name: snapshot-controller
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app spegel
+  name: spegel
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/kube-system/spegel/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/cloudflared/ks.yaml
+++ b/kubernetes/apps/network/cloudflared/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app cloudflared
+  name: cloudflared
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/network/cloudflared/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/echo/ks.yaml
+++ b/kubernetes/apps/network/echo/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app echo
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/network/echo/app
   postBuild:
     substitute:

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app envoy-gateway
+  name: envoy-gateway
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/network/envoy-gateway/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/external-dns/ks.yaml
+++ b/kubernetes/apps/network/external-dns/ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app external-dns-common
+  name: external-dns-common
 spec:
   path: ./kubernetes/apps/network/external-dns/common
   prune: true
@@ -19,11 +19,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app external-dns-cloudflare
+  name: external-dns-cloudflare
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/network/external-dns/cloudflare
   prune: true
   sourceRef:
@@ -38,11 +35,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app external-dns-unifi
+  name: external-dns-unifi
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/network/external-dns/unifi
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/k8s-gateway/ks.yaml
+++ b/kubernetes/apps/network/k8s-gateway/ks.yaml
@@ -3,12 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app tailscale-dns
+  name: tailscale-dns
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/instance: *app
-      app.kubernetes.io/name: k8s-gateway
   path: ./kubernetes/apps/network/k8s-gateway/tailscale-dns
   prune: true
   sourceRef:

--- a/kubernetes/apps/network/openspeedtest/ks.yaml
+++ b/kubernetes/apps/network/openspeedtest/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app openspeedtest
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/network/openspeedtest/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/nvidia-dra-driver-gpu/nvidia-dra-driver-gpu/ks.yaml
+++ b/kubernetes/apps/nvidia-dra-driver-gpu/nvidia-dra-driver-gpu/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app nvidia-dra-driver-gpu
+  name: nvidia-dra-driver-gpu
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/nvidia-dra-driver-gpu/nvidia-dra-driver-gpu/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability-agents/fluent-bit/ks.yaml
+++ b/kubernetes/apps/observability-agents/fluent-bit/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app fluent-bit
+  name: fluent-bit
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability-agents/fluent-bit/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability-agents/node-exporter/ks.yaml
+++ b/kubernetes/apps/observability-agents/node-exporter/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app node-exporter
+  name: node-exporter
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability-agents/node-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability-agents/scrutiny-collector/ks.yaml
+++ b/kubernetes/apps/observability-agents/scrutiny-collector/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app scrutiny-collector
+  name: scrutiny-collector
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: scrutiny
       namespace: observability
@@ -25,11 +22,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app scrutiny-collector-zfs
+  name: scrutiny-collector-zfs
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: scrutiny
       namespace: observability

--- a/kubernetes/apps/observability-agents/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability-agents/smartctl-exporter/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app smartctl-exporter
+  name: smartctl-exporter
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability-agents/smartctl-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability-agents/telegraf/ks.yaml
+++ b/kubernetes/apps/observability-agents/telegraf/ks.yaml
@@ -3,13 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app telegraf-powerwall
+  name: telegraf-powerwall
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/instance: *app
-      app.kubernetes.io/name: telegraf
-      app.kubernetes.io/part-of: powerwall-dashboard
   path: ./kubernetes/apps/observability-agents/telegraf/powerwall
   prune: true
   sourceRef:
@@ -24,12 +19,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app telegraf-zfs
+  name: telegraf-zfs
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/instance: *app
-      app.kubernetes.io/name: telegraf
   path: ./kubernetes/apps/observability-agents/telegraf/zfs
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/alloy/ks.yaml
+++ b/kubernetes/apps/observability/alloy/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app alloy
+  name: alloy
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/alloy/alloy
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/beszel/ks.yaml
+++ b/kubernetes/apps/observability/beszel/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app beszel
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/observability/beszel/app

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app blackbox-exporter
+  name: blackbox-exporter
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/blackbox-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/dozzle/ks.yaml
+++ b/kubernetes/apps/observability/dozzle/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app dozzle
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/envoy-gateway-oidc
   path: ./kubernetes/apps/observability/dozzle/app

--- a/kubernetes/apps/observability/exportarr/ks.yaml
+++ b/kubernetes/apps/observability/exportarr/ks.yaml
@@ -2,11 +2,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app exportarr
+  name: exportarr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/exportarr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -2,11 +2,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app gatus
+  name: gatus
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/gatus/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app grafana-dashboards
+  name: grafana-dashboards
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/grafana/dashboards
   prune: true
   sourceRef:
@@ -22,11 +19,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app grafana-instance
+  name: grafana-instance
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   dependsOn:
@@ -49,11 +43,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app grafana-operator
+  name: grafana-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/grafana/operator
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/headlamp/ks.yaml
+++ b/kubernetes/apps/observability/headlamp/ks.yaml
@@ -2,11 +2,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app headlamp
+  name: headlamp
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/headlamp/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/idrac-exporter/ks.yaml
+++ b/kubernetes/apps/observability/idrac-exporter/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app idrac-exporter
+  name: idrac-exporter
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/idrac-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/kite/ks.yaml
+++ b/kubernetes/apps/observability/kite/ks.yaml
@@ -2,11 +2,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app kite
+  name: kite
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/kite/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app kps
+  name: kps
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager
       namespace: cert-manager

--- a/kubernetes/apps/observability/netronome/ks.yaml
+++ b/kubernetes/apps/observability/netronome/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app netronome
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/observability/netronome/app

--- a/kubernetes/apps/observability/nut-exporter/ks.yaml
+++ b/kubernetes/apps/observability/nut-exporter/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app nut-exporter
+  name: nut-exporter
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/nut-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/pulse/ks.yaml
+++ b/kubernetes/apps/observability/pulse/ks.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 metadata:
   name: &app pulse
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/observability/pulse/app

--- a/kubernetes/apps/observability/scrutiny/ks.yaml
+++ b/kubernetes/apps/observability/scrutiny/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app scrutiny
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/observability/scrutiny/app

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app silence-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -27,11 +24,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app silence-operator-silences
+  name: silence-operator-silences
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: silence-operator
   path: ./kubernetes/apps/observability/silence-operator/silences

--- a/kubernetes/apps/observability/siren/ks.yaml
+++ b/kubernetes/apps/observability/siren/ks.yaml
@@ -2,11 +2,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app siren
+  name: siren
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/siren/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/speedtest-exporter/ks.yaml
+++ b/kubernetes/apps/observability/speedtest-exporter/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app speedtest-exporter
+  name: speedtest-exporter
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: kubernetes/apps/observability/speedtest-exporter/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/unpoller/ks.yaml
+++ b/kubernetes/apps/observability/unpoller/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app unpoller
+  name: unpoller
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/unpoller/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/observability/victoria/ks.yaml
+++ b/kubernetes/apps/observability/victoria/ks.yaml
@@ -59,11 +59,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app victoria-operator
+  name: victoria-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager
       namespace: cert-manager
@@ -82,11 +79,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app victoria-operator-crds
+  name: victoria-operator-crds
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/observability/victoria/operator-crds
   prune: false
   sourceRef:

--- a/kubernetes/apps/openebs-system/openebs-localpv/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs-localpv/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app openebs-localpv
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app openebs
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/rook-ceph/cluster/ks.yaml
+++ b/kubernetes/apps/rook-ceph/cluster/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app rook-ceph-cluster
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: rook-ceph-operator
     - name: snapshot-controller

--- a/kubernetes/apps/rook-ceph/operator/ks.yaml
+++ b/kubernetes/apps/rook-ceph/operator/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app rook-ceph-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/storage/kantai1-samba/ks.yaml
+++ b/kubernetes/apps/storage/kantai1-samba/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app kantai1-samba
+  name: kantai1-samba
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/storage/kantai1-samba/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/storage/kantai3-samba/ks.yaml
+++ b/kubernetes/apps/storage/kantai3-samba/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app kantai3-samba
+  name: kantai3-samba
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/storage/kantai3-samba/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/tailscale/tailscale-operator/ks.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/ks.yaml
@@ -3,11 +3,8 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app tailscale-operator
+  name: tailscale-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   path: ./kubernetes/apps/tailscale/tailscale-operator/app
   prune: true
   sourceRef:
@@ -22,11 +19,8 @@ spec:
 # apiVersion: kustomize.toolkit.fluxcd.io/v1
 # kind: Kustomization
 # metadata:
-#   name: &app tailscale-connector
+#   name: tailscale-connector
 # spec:
-#   commonMetadata:
-#     labels:
-#       app.kubernetes.io/name: *app
 #   dependsOn:
 #     - name: tailscale-operator
 #   path: ./kubernetes/apps/tailscale/tailscale-operator/connector

--- a/kubernetes/apps/talos-admin/talos-backup/ks.yaml
+++ b/kubernetes/apps/talos-admin/talos-backup/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app talos-backup
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
   path: ./kubernetes/apps/talos-admin/talos-backup/app

--- a/kubernetes/apps/talos-admin/tuppr/ks.yaml
+++ b/kubernetes/apps/talos-admin/tuppr/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app tuppr
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -27,11 +24,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app tuppr-upgrades
+  name: tuppr-upgrades
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: tuppr
   path: ./kubernetes/apps/talos-admin/tuppr/upgrades

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: &app volsync
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: snapshot-controller
       namespace: kube-system
@@ -30,11 +27,8 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app volsync-maintenance
+  name: volsync-maintenance
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: volsync
   path: ./kubernetes/apps/volsync-system/volsync/maintenance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Kubernetes Kustomization manifests across numerous applications by removing YAML anchor-based label inheritance patterns. Eliminated automatic `app.kubernetes.io/name` label injection from commonMetadata configurations. Affected over 100 manifest files to improve maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->