### PR TITLE
ci: publish signed cluster OCI artifact

### DIFF
--- a/.github/workflows/cluster-release.yaml
+++ b/.github/workflows/cluster-release.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+name: Cluster Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/cluster-release.yaml
+      - kubernetes/**
+
+concurrency:
+  group: cluster-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  OCI_REPOSITORY: ghcr.io/${{ github.repository }}/cluster
+
+jobs:
+  release:
+    name: Cluster Release - Build, Sign, and Publish
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main ref
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Cluster releases must run from refs/heads/main" >&2
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@889be9d6cc8afa8ed639e1e1ba4ab678e3b38d8c # v2.9.4
+        with:
+          token: ${{ github.token }}
+          # renovate: datasource=github-releases depName=fluxcd/flux2
+          version: 2.9.4
+
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # renovate: datasource=github-releases depName=sigstore/cosign
+          cosign-release: v3.1.3
+
+      - name: Login to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Publish immutable artifact
+        id: publish
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/cluster-artifact
+        run: |
+          mkdir -p "${ARTIFACT_DIR}/kubernetes"
+          cp -a kubernetes/. "${ARTIFACT_DIR}/kubernetes/"
+          result="$(flux push artifact "oci://${OCI_REPOSITORY}:${GITHUB_SHA}" \
+            --path "${ARTIFACT_DIR}" \
+            --source "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --revision "${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}" \
+            --reproducible \
+            --output json)"
+          digest="$(jq -er '.digest' <<< "${result}")"
+          echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Sign and verify artifact
+        env:
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          cosign sign --yes --new-bundle-format=false "${OCI_REPOSITORY}@${DIGEST}"
+          cosign verify \
+            --new-bundle-format=false \
+            --certificate-identity "${GITHUB_SERVER_URL}/${GITHUB_WORKFLOW_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${OCI_REPOSITORY}@${DIGEST}"
+
+      - name: Require main tip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tip="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
+          if [[ "${tip}" != "${GITHUB_SHA}" ]]; then
+            echo "${GITHUB_SHA} is not the tip of main (${tip}); refusing to promote" >&2
+            exit 1
+          fi
+
+      - name: Promote artifact
+        env:
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          flux tag artifact "oci://${OCI_REPOSITORY}@${DIGEST}" --tag latest

--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -3,7 +3,7 @@
   customManagers: [
     {
       customType: "regex",
-      managerFilePatterns: ["/^(kubernetes|talos)/.+\\.yaml$/"],
+      managerFilePatterns: ["/^(kubernetes|talos)/.+\\.yaml$/", "/^\\.github/workflows/.+\\.ya?ml$/"],
       matchStrings: [
         // # renovate: datasource=github-releases depName=org/repo versioning=loose
         // version: 1.2.3

--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -2,6 +2,11 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
+      matchDatasources: ["github-releases"],
+      matchPackageNames: ["fluxcd/flux2"],
+      extractVersion: "^v(?<version>.+)$",
+    },
+    {
       matchDatasources: ["docker"],
       matchPackageNames: ["ghcr.io/home-operations/plex"],
       versioning: "loose"


### PR DESCRIPTION
## Summary

- build and publish the `kubernetes/` tree as an OCI artifact on pushes to `main`
- publish an immutable SHA tag to GHCR
- keylessly sign and verify the artifact with GitHub OIDC/Cosign
- promote the verified digest to `latest`
- reject `workflow_dispatch` runs from non-main refs

## Rollout gate

This is step 1 of the OCI migration. After merge, confirm the **Cluster Release** workflow succeeds and `ghcr.io/jfroy/flatops/cluster:latest` exists before merging the next PR. This seeds the signed artifact without changing Flux.

## Stack

1. **This PR:** publish and seed the signed artifact
2. Bootstrap a verified OCI source and OIDC Receiver
3. Migrate default-namespace Kustomizations
4. Complete the source migration and transfer source ownership to FluxInstance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the cluster artifact release process with automated build, validation, signing, and promotion steps.
  - Releases now publish verified, immutable artifacts and maintain a reliable `latest` reference.
  - Added safeguards to ensure releases are produced only from the designated main code line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->