### PR TITLE
refactor(flux): migrate default apps to OCI source

### DIFF
--- a/kubernetes/apps/default/autobrr/ks.yaml
+++ b/kubernetes/apps/default/autobrr/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/autobrr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/bookorbit/ks.yaml
+++ b/kubernetes/apps/default/bookorbit/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/bookorbit/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/browserr/ks.yaml
+++ b/kubernetes/apps/default/browserr/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/browserr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/buildkit/ks.yaml
+++ b/kubernetes/apps/default/buildkit/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/buildkit/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/changedetection/ks.yaml
+++ b/kubernetes/apps/default/changedetection/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/changedetection/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/crd-schema-publisher/ks.yaml
+++ b/kubernetes/apps/default/crd-schema-publisher/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/crd-schema-publisher/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/dawarich/ks.yaml
+++ b/kubernetes/apps/default/dawarich/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/dawarich/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/docker-registry-ui/ks.yaml
+++ b/kubernetes/apps/default/docker-registry-ui/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/docker-registry-ui/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/docling/ks.yaml
+++ b/kubernetes/apps/default/docling/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/docling/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/esphome/ks.yaml
+++ b/kubernetes/apps/default/esphome/ks.yaml
@@ -11,7 +11,7 @@ spec:
   path: ./kubernetes/apps/default/esphome/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/etampe/ks.yaml
+++ b/kubernetes/apps/default/etampe/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/etampe/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/familynido/ks.yaml
+++ b/kubernetes/apps/default/familynido/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/familynido/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/filebrowser/ks.yaml
+++ b/kubernetes/apps/default/filebrowser/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/filebrowser/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/glance/ks.yaml
+++ b/kubernetes/apps/default/glance/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/glance/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/gluetun/ks.yaml
+++ b/kubernetes/apps/default/gluetun/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/gluetun/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/grimmory/ks.yaml
+++ b/kubernetes/apps/default/grimmory/ks.yaml
@@ -13,7 +13,7 @@ spec:
   path: ./kubernetes/apps/default/grimmory/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/homebox/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/homepage/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/houndarr/ks.yaml
+++ b/kubernetes/apps/default/houndarr/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/houndarr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/immich/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h
@@ -30,7 +30,7 @@ spec:
   path: ./kubernetes/apps/default/immich/frame
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h
@@ -55,7 +55,7 @@ spec:
   path: ./kubernetes/apps/default/immich/pet-tagger
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h
@@ -78,7 +78,7 @@ spec:
   path: ./kubernetes/apps/default/immich/valkey
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/jellyfin/ks.yaml
+++ b/kubernetes/apps/default/jellyfin/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/jellyfin/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/karakeep/ks.yaml
+++ b/kubernetes/apps/default/karakeep/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/karakeep/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/komga/ks.yaml
+++ b/kubernetes/apps/default/komga/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/komga/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/labby/ks.yaml
+++ b/kubernetes/apps/default/labby/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/labby/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/livesync/ks.yaml
+++ b/kubernetes/apps/default/livesync/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/livesync/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/mealie/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/media-pv/ks.yaml
+++ b/kubernetes/apps/default/media-pv/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/media-pv/app
   prune: false  # don't GC local ZFS volumes
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/memos/ks.yaml
+++ b/kubernetes/apps/default/memos/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/memos/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/miniflux/ks.yaml
+++ b/kubernetes/apps/default/miniflux/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/miniflux/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/netbox/ks.yaml
+++ b/kubernetes/apps/default/netbox/ks.yaml
@@ -12,7 +12,7 @@ spec:
   path: ./kubernetes/apps/default/netbox/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h
@@ -40,7 +40,7 @@ spec:
   path: ./kubernetes/apps/default/netbox/valkey
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/nextflux/ks.yaml
+++ b/kubernetes/apps/default/nextflux/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/nextflux/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/notifier/ks.yaml
+++ b/kubernetes/apps/default/notifier/ks.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/default/notifier/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   targetNamespace: default

--- a/kubernetes/apps/default/octoeverywhere-bambu-connect/ks.yaml
+++ b/kubernetes/apps/default/octoeverywhere-bambu-connect/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/octoeverywhere-bambu-connect/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/ollama/ks.yaml
+++ b/kubernetes/apps/default/ollama/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/ollama/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/open-webui/ks.yaml
+++ b/kubernetes/apps/default/open-webui/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/open-webui/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/openspoolman/ks.yaml
+++ b/kubernetes/apps/default/openspoolman/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/openspoolman/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/oxicloud/ks.yaml
+++ b/kubernetes/apps/default/oxicloud/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/oxicloud/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/paperless/ks.yaml
+++ b/kubernetes/apps/default/paperless/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/paperless/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h
@@ -32,7 +32,7 @@ spec:
 #   path: ./kubernetes/apps/default/paperless/ai
 #   prune: true
 #   sourceRef:
-#     kind: GitRepository
+#     kind: OCIRepository
 #     name: flux-system
 #     namespace: flux-system
 #   interval: 1h
@@ -54,7 +54,7 @@ spec:
 #   path: ./kubernetes/apps/default/paperless/gpt
 #   prune: true
 #   sourceRef:
-#     kind: GitRepository
+#     kind: OCIRepository
 #     name: flux-system
 #     namespace: flux-system
 #   interval: 1h

--- a/kubernetes/apps/default/pgadmin/ks.yaml
+++ b/kubernetes/apps/default/pgadmin/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/pgadmin/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/photon/ks.yaml
+++ b/kubernetes/apps/default/photon/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/photon/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/pinchflat/ks.yaml
+++ b/kubernetes/apps/default/pinchflat/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/pinchflat/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/plex/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/pocket-id/ks.yaml
+++ b/kubernetes/apps/default/pocket-id/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/pocket-id/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/prowlarr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/pvforecast/ks.yaml
+++ b/kubernetes/apps/default/pvforecast/ks.yaml
@@ -11,7 +11,7 @@ spec:
   path: ./kubernetes/apps/default/pvforecast/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/qbittorrent/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/qui/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -11,7 +11,7 @@ spec:
   path: ./kubernetes/apps/default/radarr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/readur/ks.yaml
+++ b/kubernetes/apps/default/readur/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/readur/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/recyclarr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -11,7 +11,7 @@ spec:
   path: ./kubernetes/apps/default/sabnzbd/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/seerr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/shelfmark/ks.yaml
+++ b/kubernetes/apps/default/shelfmark/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/shelfmark/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -11,7 +11,7 @@ spec:
   path: ./kubernetes/apps/default/sonarr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/spoolman/ks.yaml
+++ b/kubernetes/apps/default/spoolman/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/spoolman/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/stash/ks.yaml
+++ b/kubernetes/apps/default/stash/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/stash/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/tracearr/ks.yaml
+++ b/kubernetes/apps/default/tracearr/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/tracearr/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/ytptube/ks.yaml
+++ b/kubernetes/apps/default/ytptube/ks.yaml
@@ -10,7 +10,7 @@ spec:
   path: ./kubernetes/apps/default/ytptube/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/zipline/ks.yaml
+++ b/kubernetes/apps/default/zipline/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/zipline/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h

--- a/kubernetes/apps/default/zot/ks.yaml
+++ b/kubernetes/apps/default/zot/ks.yaml
@@ -8,7 +8,7 @@ spec:
   path: ./kubernetes/apps/default/zot/app
   prune: true
   sourceRef:
-    kind: GitRepository
+    kind: OCIRepository
     name: flux-system
     namespace: flux-system
   interval: 1h


### PR DESCRIPTION
## Summary

- migrate all default-namespace Flux Kustomizations from `GitRepository/flux-system` to the already-bootstrapped `OCIRepository/flux-system`
- keep the change mechanical and below the automated review file limit

This is safe to merge only after the bootstrap OCI source is Ready and verified. FluxInstance and the root Kustomizations remain Git-backed at this stage, providing a rollback path while application sources move to OCI.

## Stack

1. Publish and seed the signed artifact
2. Bootstrap the verified OCI source and Receiver
3. **This PR:** migrate default-namespace Kustomizations
4. Complete the source migration and transfer source ownership to FluxInstance
