### PR TITLE
fix(renovate): stop the webhook token from rotating on every spec edit

### DIFF
--- a/kubernetes/apps/renovate/renovate/jobs/externalsecret.yaml
+++ b/kubernetes/apps/renovate/renovate/jobs/externalsecret.yaml
@@ -49,8 +49,7 @@ kind: ExternalSecret
 metadata:
   name: &name webhook-token
 spec:
-  refreshPolicy: Periodic
-  refreshInterval: 8760h
+  refreshPolicy: CreatedOnce
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword


### PR DESCRIPTION
## What

`webhook-token` (`kubernetes/apps/renovate/renovate/jobs/externalsecret.yaml`) moves from `refreshPolicy: Periodic` + `refreshInterval: 8760h` to `refreshPolicy: CreatedOnce`.

## Why

The renovate operator's GitHub webhooks were registering fine but every actionable delivery was being rejected with `401`, so nothing ever triggered a Renovate run.

`webhook-token` is backed by the `password32` **generator** — its value is minted, not fetched. `refreshPolicy: Periodic` re-runs the generator on **any spec change**, not only on `refreshInterval`, and each run yields a new random token.

Timeline:

| When | What |
|---|---|
| 2026-07-09 | Operator registers hooks on 11 repos, embedding the then-current `webhook-token` value as each hook's HMAC secret |
| 2026-08-14 18:48Z | `eee96b404` adds the `allow-ref` label block to this ExternalSecret |
| 2026-08-14 18:55Z | external-secrets re-syncs on the spec change and the generator mints a **new** token |
| since | GitHub signs with the July token, the operator validates against the August one → `webhook resolve failed ... authentication failed` |

The operator cannot self-heal this: `ensureWebhook` reconciles a hook's URL, active state and event list, but deliberately never rewrites its secret — the value is write-only on every platform and cannot be drift-checked.

It stayed silent for a week because the webhook server authenticates *after* the "is this a renovate checkbox change" filter, so all the noise events (`pull_request.synchronize`, `issues.edited` on non-checkbox bodies) kept returning `200`. Only real triggers reached the auth check and got `401`.

## Reviewer notes

- `CreatedOnce` means the Secret is created if absent and never updated thereafter — exactly the semantics a generated shared secret needs. `refreshInterval` is meaningless under that policy and is dropped.
- Applying this does **not** rotate the token again: ESO sees the Secret already exists and skips.
- Out-of-band remediation is already done — the 11 stale hooks were deleted and the operator recreated all 12 (including `jfroy/flatops`, whose hook was independently missing) at `02:00:34Z` with the current token. No action needed on merge beyond letting Flux reconcile.
- Not yet observed: an auth-checked delivery succeeding. The `200`s so far are the create-ping path. The next real PR close should log `received github event` rather than `webhook resolve failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook tokens now remain stable after creation, preventing registered webhooks from being invalidated by automatic token refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->