### PR TITLE
feat(cleanrr): deploy cleanrr queue cleaner

### DIFF
--- a/kubernetes/apps/default/cleanrr/app/externalsecret.yaml
+++ b/kubernetes/apps/default/cleanrr/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cleanrr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cleanrr-secret
+    template:
+      data:
+        CLEANRR_SERVERS__RADARR__API_KEY: "{{ .RADARR_API_KEY }}"
+        CLEANRR_SERVERS__SONARR__API_KEY: "{{ .SONARR_API_KEY }}"
+  data:
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: radarr/API_KEY
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: sonarr/API_KEY

--- a/kubernetes/apps/default/cleanrr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cleanrr/app/helmrelease.yaml
@@ -47,9 +47,6 @@ spec:
                   httpGet:
                     path: /health/ready
                     port: *port
-                  periodSeconds: 10
-                  timeoutSeconds: 5
-                  failureThreshold: 5
               startup:
                 enabled: true
                 custom: true
@@ -57,8 +54,6 @@ spec:
                   httpGet:
                     path: /health/startup
                     port: *port
-                  failureThreshold: 30
-                  periodSeconds: 10
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: {drop: ["ALL"]}

--- a/kubernetes/apps/default/cleanrr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cleanrr/app/helmrelease.yaml
@@ -40,9 +40,6 @@ spec:
                   httpGet:
                     path: /health/live
                     port: &port 80
-                  periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 5
               readiness:
                 enabled: true
                 custom: true
@@ -66,11 +63,6 @@ spec:
               allowPrivilegeEscalation: false
               capabilities: {drop: ["ALL"]}
               readOnlyRootFilesystem: true
-            resources:
-              requests:
-                cpu: 10m
-              limits:
-                memory: 128Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/default/cleanrr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cleanrr/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/refs/heads/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cleanrr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  values:
+    controllers:
+      cleanrr:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          cleanrr:
+            image:
+              repository: ghcr.io/zariel/cleanrr
+              tag: v0.1.6@sha256:ff5de090d4295a56cedd8c8167d0e5b070970d3ca304090d36001c922fc8a2d0
+            env:
+              CLEANRR_LISTEN_ADDR: 0.0.0.0:80
+              CLEANRR_MINIMUM_AGE: 5m
+              CLEANRR_POLL_INTERVAL: 2m
+              CLEANRR_REMOVE_FROM_CLIENT: false
+              CLEANRR_SERVERS__RADARR__URL: http://radarr.default.svc.cluster.local
+              CLEANRR_SERVERS__SONARR__URL: http://sonarr.default.svc.cluster.local
+              TZ: America/Los_Angeles
+            envFrom:
+              - secretRef:
+                  name: cleanrr-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/live
+                    port: &port 80
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/ready
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/startup
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      cleanrr:
+        controller: cleanrr
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      cleanrr:
+        serviceName: cleanrr
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics

--- a/kubernetes/apps/default/cleanrr/app/kustomization.yaml
+++ b/kubernetes/apps/default/cleanrr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/cleanrr/ks.yaml
+++ b/kubernetes/apps/default/cleanrr/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cleanrr
+spec:
+  path: ./kubernetes/apps/default/cleanrr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./browserr/ks.yaml
   - ./buildkit/ks.yaml
   - ./changedetection/ks.yaml
+  - ./cleanrr/ks.yaml
   - ./crd-schema-publisher/ks.yaml
   - ./dawarich/ks.yaml
   - ./docker-registry-ui/ks.yaml


### PR DESCRIPTION
Deploys [cleanrr](https://github.com/Zariel/cleanrr) v0.1.6 to `default`, modeled on [onedr0p/home-ops#11566](https://github.com/onedr0p/home-ops/pull/11566) and adapted to this repo's conventions.

cleanrr is a long-running service that removes stale, import-blocked items from the Radarr and Sonarr queues — the completed downloads Arr refuses to import because they are not upgrades. Removal is from the Arr queue only: `CLEANRR_REMOVE_FROM_CLIENT: false`, so downloads and seeding are untouched.

## Configuration

- `CLEANRR_SERVERS__RADARR__URL` / `__SONARR__URL` point at the in-cluster services; both Arrs listen on port 80 here, so no explicit port is needed.
- `CLEANRR_MINIMUM_AGE: 5m` — an item must sit in the queue that long before it is eligible (upstream default is 30m).
- `CLEANRR_POLL_INTERVAL: 2m`.
- Listener on port 80 via `CLEANRR_LISTEN_ADDR` to match repo convention. Probes use `/health/startup`, `/health/live`, `/health/ready`; the ServiceMonitor scrapes `/metrics` from the same listener.
- Pod runs as 65532, the image's unprivileged user.
- No route: cleanrr has no UI, only health and metrics endpoints.
- No kopiur component: the app is stateless.

## Deviations from the upstream PR

- Uses the shared `app-template` OCIRepository in `flux-system` (same chart version, 5.1.0) instead of a per-app `OCIRepository`.
- `ClusterSecretStore: onepassword`; schemas served from `crd.kantai.xyz`.
- The ExternalSecret uses explicit `data` refs to `radarr/API_KEY` and `sonarr/API_KEY`. Upstream merges two `dataFrom.extract` blocks, which would collide here because both 1Password items name the field `API_KEY`. Same pattern homepage already uses.
- `ks.yaml` omits `targetNamespace` (the NamespaceTransformer handles it) and adds `retryInterval` / `timeout`.
- `TZ: America/Los_Angeles`; controller, container and service keys named `cleanrr`; `serviceMonitor` carries an explicit `serviceName`.

## Validation

- `v0.1.6` is the latest published tag; digest `sha256:ff5de090…` verified against the ghcr manifest.
- `kustomize build` clean for both the app and the namespace kustomization.
- `helm template` against app-template 5.1.0 renders ServiceAccount, Service, Deployment, ServiceMonitor.
- `kubectl apply --dry-run=server` accepted the Kustomization, HelmRelease and ExternalSecret.

## Note

Upstream's README suggests starting with `CLEANRR_DRY_RUN=true` to confirm the removal policy against real queues before it deletes anything. This PR does not set it, matching the upstream PR. Easy to add if we want a validation period first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cleanrr as a managed application deployment.
  * Configured integration with Radarr and Sonarr, including secure API credential handling.
  * Added health checks, metrics monitoring, and HTTP service exposure.
  * Configured secure container execution and resource limits.
  * Enabled automated deployment reconciliation and cleanup through the platform’s deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->