### PR TITLE
feat(homepage)!: upgrade to v2 with native OIDC auth

### DIFF
--- a/kubernetes/apps/default/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homepage/app/externalsecret.yaml
@@ -11,6 +11,12 @@ spec:
   target:
     name: homepage-secret
   data:
+    - secretKey: HOMEPAGE_OIDC_CLIENT_ID
+      remoteRef:
+        key: homepage-oidc/client-id
+    - secretKey: HOMEPAGE_OIDC_CLIENT_SECRET
+      remoteRef:
+        key: homepage-oidc/client-secret
     - secretKey: HOMEPAGE_VAR_CHANGE_DETECTION_API_KEY
       remoteRef:
         key: changedetection/credential
@@ -47,3 +53,24 @@ spec:
     - secretKey: HOMEPAGE_VAR_UNIFI_API_KEY
       remoteRef:
         key: unifi/credential
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage-auth
+spec:
+  # Rotating this signing key invalidates every live session.
+  refreshPolicy: CreatedOnce
+  target:
+    name: homepage-auth
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: password64
+      rewrite:
+        - regexp:
+            source: "password"
+            target: "HOMEPAGE_AUTH_SECRET"

--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -19,9 +19,13 @@ spec:
           homepage:
             image:
               repository: ghcr.io/gethomepage/homepage
-              tag: v1.13.2@sha256:a0b71c8e757298d02560186bab9fbe3fc2d375c523a62cc1019177b37e48aa28
+              tag: v2.1.2@sha256:da9dca9ec258c628146bed1445da0853f2b88f0b10bafd97c091de807c363d60
             env:
-              HOMEPAGE_ALLOWED_HOSTS: "*"
+              HOMEPAGE_ALLOWED_HOSTS: "${APP_SUBDOMAIN:-${APP}}.kantai.xyz"
+              HOMEPAGE_AUTH_ENABLED: "true"
+              HOMEPAGE_EXTERNAL_URL: https://${APP_SUBDOMAIN:-${APP}}.kantai.xyz
+              HOMEPAGE_OIDC_ISSUER: https://pid.kantai.xyz
+              HOMEPAGE_OIDC_NAME: Pocket ID
               NODE_OPTIONS: "--max-http-header-size=65536"
               PUID: 1000
               PGID: 1000
@@ -29,6 +33,8 @@ spec:
             envFrom:
               - secretRef:
                   name: homepage-secret
+              - secretRef:
+                  name: homepage-auth
             probes:
               liveness:
                 enabled: true
@@ -37,9 +43,16 @@ spec:
                   httpGet:
                     path: /api/healthcheck
                     port: &port 3000
+                    httpHeaders:
+                      # HOMEPAGE_ALLOWED_HOSTS is validated before the
+                      # /api/healthcheck auth exemption, and kubelet would
+                      # otherwise send the pod IP as Host and get a 400.
+                      - name: Host
+                        value: localhost:3000
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }
+              readOnlyRootFilesystem: true
         serviceAccount:
           identifier: homepage
     defaultPodOptions:
@@ -50,6 +63,11 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
     persistence:
+      cache:
+        type: emptyDir
+        sizeLimit: 100Mi
+        globalMounts:
+          - path: /app/.next/cache
       homepage-config:
         type: configMap
         name: homepage-config
@@ -60,6 +78,11 @@ spec:
         sizeLimit: 100Mi
         globalMounts:
           - path: /app/config/logs
+      tmp:
+        type: emptyDir
+        sizeLimit: 100Mi
+        globalMounts:
+          - path: /tmp
     route:
       homepage:
         hostnames:

--- a/kubernetes/apps/default/homepage/ks.yaml
+++ b/kubernetes/apps/default/homepage/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: &app homepage
 spec:
-  components:
-    - ../../../../components/envoy-gateway-oidc
   path: ./kubernetes/apps/default/homepage/app
   prune: true
   sourceRef:


### PR DESCRIPTION
Supersedes #2260, which bumped the tag only.

Homepage 2.0 adds a built-in auth gate. This switches homepage from the edge-only `envoy-gateway-oidc` SecurityPolicy to its native OIDC support against Pocket ID, which also closes in-cluster access to `/api/proxy` and the widget credentials it fronts.

## Changes

- **`ks.yaml`** — drop the `envoy-gateway-oidc` component. Flux prune removes the `homepage-oidc` SecurityPolicy and its ExternalSecret.
- **`helmrelease.yaml`** — `v2.1.2` (same digest Renovate resolved), native OIDC env, tightened `HOMEPAGE_ALLOWED_HOSTS`, liveness probe `Host` header, `readOnlyRootFilesystem: true` plus emptyDirs for `/app/.next/cache` and `/tmp`.
- **`externalsecret.yaml`** — `HOMEPAGE_OIDC_CLIENT_ID`/`_SECRET` folded into `homepage-secret` from the same `homepage-oidc/*` 1Password fields the component used. New `homepage-auth` ExternalSecret generates `HOMEPAGE_AUTH_SECRET` via the `password64` generator with `refreshPolicy: CreatedOnce`, so a spec edit cannot silently re-mint the signing key and sign every live session out.

## Why the probe needs a Host header

v2 widens the middleware matcher from `/api/:path*` to all routes, so `HOMEPAGE_ALLOWED_HOSTS` now gates page loads too. Host validation runs *ahead* of the `/api/healthcheck` auth exemption, so kubelet's default pod-IP `Host` returns 400 once the wildcard is removed. Confirmed below.

## Verification

Rendered the chart (`helm template ... app-template 5.1.0`) — `httpHeaders` passes through. Then ran the real `v2.1.2` image locally with `--read-only` and the actual config files from this repo:

| check | result |
|---|---|
| start, read-only rootfs | clean, no `EROFS`/`EACCES` |
| `/api/healthcheck`, `Host: localhost:3000` | `200` |
| `/api/healthcheck`, `Host: 10.42.1.7:3000` | `400` — probe header is required, not cosmetic |
| `/` unauthenticated | `307 -> /auth/signin` |
| `/api/widgets/kubernetes` unauthenticated | `307 -> /auth/signin` |
| `/api/config/custom.css` | `200` (documented exemption) |
| `/api/auth/providers` | only `homepage-oidc`, no credentials provider |

The provider check also confirms `HOMEPAGE_EXTERNAL_URL` -> `NEXTAUTH_URL` resolves correctly, returning `https://homepage.kantai.xyz/api/auth/callback/homepage-oidc`.

## Pocket ID — done, no action needed

The existing `Homepage` client (`97a8bd69-5c83-4b0e-99c8-a6223271e934`) has been updated via the API. A new client was deliberately *not* created: its secret is what `homepage-oidc/client-id` and `homepage-oidc/client-secret` in 1Password already hold, which is what this PR reuses, so a second client would have minted credentials that don't match the vault.

Callback URLs are now:

```
https://homepage.kantai.xyz/oauth2/callback                    (kept, rollback)
https://homepage.kantai.xyz/api/auth/callback/homepage-oidc    (added)
```

The old Envoy callback is intentionally retained so reverting this PR restores working auth with no IdP change. The client was already unrestricted (`isGroupRestricted: false`, no allowed groups) and its logo is now the selfh.st SVG. Verified afterward that the existing client secret is untouched.

Host stays on `envoy-internal`, so LAN/tailnet-only exposure is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)