### PR TITLE
feat(observability): deploy kubagachi

### DIFF
--- a/kubernetes/apps/observability/kubagachi/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kubagachi/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kubagachi
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: kubagachi-chart
+  values:
+    # in-cluster mode (default): watches this cluster via the pod's own
+    # ServiceAccount, using the RBAC the chart provisions below.
+    rbac:
+      create: true
+      clusterRead: true
+      # The embedded terminal (pods/exec + pods/attach) is a broad write
+      # surface on top of the already-broad cluster-wide read. Off by
+      # default per upstream's own security guidance; flip to true if the
+      # exec terminal is wanted.
+      podExec: false

--- a/kubernetes/apps/observability/kubagachi/app/httproute.yaml
+++ b/kubernetes/apps/observability/kubagachi/app/httproute.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app.kubernetes.io/name: kubagachi
+  name: kubagachi
+spec:
+  hostnames:
+    - kubagachi.kantai.xyz
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: kubagachi
+          port: 80

--- a/kubernetes/apps/observability/kubagachi/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kubagachi/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/kubagachi/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kubagachi/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kubagachi-chart
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.0
+  url: oci://ghcr.io/yscale-sh/charts/kubagachi

--- a/kubernetes/apps/observability/kubagachi/ks.yaml
+++ b/kubernetes/apps/observability/kubagachi/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://crd.kantai.xyz/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kubagachi
+spec:
+  components:
+    - ../../../../components/envoy-gateway-oidc
+  path: ./kubernetes/apps/observability/kubagachi/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./grafana/ks.yaml
   # - ./idrac-exporter/ks.yaml
   - ./kite/ks.yaml
+  - ./kubagachi/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./netronome/ks.yaml
   - ./nut-exporter/ks.yaml


### PR DESCRIPTION
Add the Kubagachi cockpit (https://github.com/Yscale-sh/Kubagachi) to the
observability namespace via its published OCI chart
(oci://ghcr.io/yscale-sh/charts/kubagachi, 0.1.0).

- OCIRepository + HelmRelease with rbac.podExec disabled: the chart's
  cluster-wide read RBAC is kept (needed for the dashboard), but the
  pods/exec terminal is off by default per upstream's own security
  guidance, since it's a broad write surface on a shared cluster.
- Standalone HTTPRoute on envoy-internal (the chart only supports classic
  Ingress natively) plus the envoy-gateway-oidc component, since the app
  ships with no built-in authentication.

Requires a 1Password entry "kubagachi-oidc" (client-id/client-secret) from
an OIDC client registered against https://pid.kantai.xyz with redirect URL
https://kubagachi.kantai.xyz/oauth2/callback before the route will
authenticate.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gs6cgwVnpPmrYSKZToLjJ4
