### PR TITLE
feat(litellm): add gpt-6-astra model

### DIFF
--- a/kubernetes/apps/litellm/litellm/app/litellmmodels.yaml
+++ b/kubernetes/apps/litellm/litellm/app/litellmmodels.yaml
@@ -95,6 +95,20 @@ spec:
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
+  name: gpt-6-astra
+spec:
+  proxyRef: litellm
+  modelName: gpt-6-astra
+  params:
+    model: openai/gpt-6-astra
+    apiKeyRef:
+      name: litellm
+      key: OPENAI_API_KEY
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
   name: text-embedding-3-small
 spec:
   proxyRef: litellm

--- a/kubernetes/apps/litellm/litellm/app/litellmvirtualkeys.yaml
+++ b/kubernetes/apps/litellm/litellm/app/litellmvirtualkeys.yaml
@@ -34,6 +34,7 @@ spec:
     - gpt-5.6-sol
     - gpt-5.6-terra
     - gpt-5.6-luna
+    - gpt-6-astra
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmvirtualkey_v1alpha1.json
 apiVersion: litellm.home-operations.com/v1alpha1
@@ -54,3 +55,4 @@ spec:
     - gpt-5.6-sol
     - gpt-5.6-terra
     - gpt-5.6-luna
+    - gpt-6-astra


### PR DESCRIPTION
Register `gpt-6-astra` as an OpenAI-backed LiteLLM model and grant access to the `opencode` and `openshell` virtual keys.

Validation:
- `kustomize build kubernetes/apps/litellm/litellm/app`
- `yq` assertions for the model and virtual-key grants
- `git diff --check`