### PR TITLE
fix(observability): upgrade kube-prometheus-stack to 90.0.0 and provide auth token

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -35,8 +35,17 @@ spec:
         matchLabels:
           grafana.internal/instance: grafana
 
+    coreDns:
+      serviceMonitor:
+        authorization: &cpAuth
+          type: Bearer
+          credentials:
+            name: vmagent-kantai-token
+            key: token
+
     kubeApiServer:
       serviceMonitor:
+        authorization: *cpAuth
         metricRelabelings:
           - action: drop
             sourceLabels: ["__name__"]
@@ -56,6 +65,7 @@ spec:
 
     kubelet:
       serviceMonitor:
+        authorization: *cpAuth
         cAdvisorMetricRelabelings:
           # Drop less useful container CPU metrics.
           - sourceLabels: [__name__]
@@ -106,6 +116,7 @@ spec:
         - 10.1.1.2
         - 10.1.1.3
       serviceMonitor:
+        authorization: *cpAuth
         metricRelabelings:
           - action: drop
             sourceLabels: ["__name__"]
@@ -113,10 +124,13 @@ spec:
 
     kubeEtcd:
       endpoints: *cp
+      serviceMonitor:
+        authorization: *cpAuth
 
     kubeScheduler:
       endpoints: *cp
       serviceMonitor:
+        authorization: *cpAuth
         metricRelabelings:
           - action: drop
             sourceLabels: ["__name__"]

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./ocirepository.yaml
   - ./prometheusrule.yaml
   - ./scrapeconfig.yaml
+  - ./secret.yaml

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
   ref:
-    tag: 89.2.4
+    tag: 90.0.0

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/secret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vmagent-kantai-token
+  annotations:
+    kubernetes.io/service-account.name: vmagent-kantai
+type: kubernetes.io/service-account-token

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -8,6 +8,7 @@ spec:
   dependsOn:
     - name: cert-manager
       namespace: cert-manager
+    - name: victoria-metrics
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app
   prune: true
   sourceRef:


### PR DESCRIPTION
kube-prometheus-stack 90.0.0 replaces `bearerTokenFile` on the control-plane ServiceMonitors with `authorization` pointing at a Secret. The chart creates that Secret only alongside its own Prometheus, which is disabled here, so the bump on its own fails to render.

vmagent scrapes these targets, so point every enabled control-plane component at a long-lived token Secret for the `vmagent-kantai` ServiceAccount — the same identity the old `bearerTokenFile` resolved to.