### PR TITLE
feat(konflate): render with the cluster's capabilities

### DIFF
--- a/kubernetes/apps/flux-system/konflate/ks/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks/helmrelease.yaml
@@ -19,6 +19,8 @@ spec:
       verifyImages: true
       maxDiffConcurrency: 2
       renderConcurrency: "8"
+      kubeVersion: '{{ .Capabilities.KubeVersion.Version }}'
+      helmApiVersions: '{{ join "," .Capabilities.APIVersions }}'
     secret:
       existingSecret: konflate
     httpRoute:

--- a/kubernetes/apps/flux-system/konflate/ks/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks/ocirepository.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.6.3
+    tag: 0.6.4
   url: oci://ghcr.io/home-operations/charts/konflate
   verify:
     provider: cosign


### PR DESCRIPTION
Bump the chart to 0.6.4 and set `config.kubeVersion` and `config.helmApiVersions`, added in home-operations/konflate#519, to this release's own `.Capabilities`.

konflate templates charts offline with no API server to discover from, so `.Capabilities.APIVersions` was helm's built-in core set and `.Capabilities.KubeVersion` was whatever the helm SDK konflate was built against. A chart gated on a CRD or feature-gated API (`.Capabilities.APIVersions.Has` — the gpu-operator DRA guard, for one), or on the cluster version, rendered differently here than in-cluster, or failed outright.

The chart `tpl`s both values at install time and helm-controller resolves capabilities against kantai, which is also konflate's render target, so these track the cluster with nothing static to maintain.